### PR TITLE
Reduce number of transfer buffers to 50 on Windows

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -215,6 +215,8 @@ typedef struct uvc_device_info {
  */
 #ifdef __APPLE__
 #define LIBUVC_NUM_TRANSFER_BUFS 8
+#elif WIN32
+#define LIBUVC_NUM_TRANSFER_BUFS 50
 #else
 #define LIBUVC_NUM_TRANSFER_BUFS 100
 #endif


### PR DESCRIPTION
The large number of transfers was causing a higher rate of events, and
in turn, high CPU usage