### PR TITLE
Fix pyuvc build errors

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -10,7 +10,7 @@ extern "C" {
 #ifndef WIN32
 #include <sys/time.h>
 #else
-#include <winsock2.h>
+#include <winsock.h>
 #endif
 #include <libuvc/libuvc_config.h>
 


### PR DESCRIPTION
Use winsock.h instead of winsock2.h to prevent type redefinition errors