### PR TITLE
Add libusb lib location explicitly; Windows incompatible?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(WIN32)
   PATHS /opt/local/include)
 else()
   find_package(PkgConfig)
-  pkg_check_modules(LIBUSB libusb-1.0)
+  pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 endif()
 
 
@@ -55,7 +55,7 @@ SET(SOURCES src/ctrl.c src/ctrl-gen.c src/device.c src/diag.c
 include_directories(
   ${libuvc_SOURCE_DIR}/include
   ${libuvc_BINARY_DIR}/include
-  ${LIBUSB_INCLUDE_DIR}
+  ${LIBUSB_INCLUDEDIR}
   ${PTHREAD_INCLUDE_DIR}
 )
 
@@ -93,7 +93,7 @@ foreach(target_name ${UVC_TARGETS})
 endforeach()
 
 if(BUILD_UVC_SHARED)
-  target_link_libraries(uvc ${LIBUSB_LIBRARIES} ${PTHREAD_LIBRARIES})
+  target_link_libraries(uvc "-L${LIBUSB_LIBRARY_DIRS}" ${LIBUSB_LIBRARIES} ${PTHREAD_LIBRARIES})
 
   #add_executable(test src/test.c)
   #target_link_libraries(test uvc ${LIBUSB_LIBRARIES} opencv_highgui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ if (NOT CMAKE_BUILD_TARGET)
 endif()
 
 set(libuvc_VERSION_MAJOR 0)
-set(libuvc_VERSION_MINOR 0)
-set(libuvc_VERSION_PATCH 9)
+set(libuvc_VERSION_MINOR 1)
+set(libuvc_VERSION_PATCH 0)
 set(libuvc_VERSION ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH})
 
 set(libuvc_DESCRIPTION "A cross-platform library for USB video devices")

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -514,7 +514,8 @@ uvc_error_t uvc_find_devices(
 
 uvc_error_t uvc_open(
     uvc_device_t *dev,
-    uvc_device_handle_t **devh);
+    uvc_device_handle_t **devh,
+    int should_detach_kernel_driver);
 void uvc_close(uvc_device_handle_t *devh);
 
 uvc_device_t *uvc_get_device(uvc_device_handle_t *devh);
@@ -543,31 +544,34 @@ uvc_error_t uvc_get_stream_ctrl_format_size(
     uvc_stream_ctrl_t *ctrl,
     enum uvc_frame_format format,
     int width, int height,
-    int fps
+    int fps, int should_detach_kernel_driver
     );
 
 const uvc_format_desc_t *uvc_get_format_descs(uvc_device_handle_t* );
 
 uvc_error_t uvc_probe_stream_ctrl(
     uvc_device_handle_t *devh,
-    uvc_stream_ctrl_t *ctrl);
+    uvc_stream_ctrl_t *ctrl,
+    int should_detach_kernel_driver);
 
 uvc_error_t uvc_start_streaming(
     uvc_device_handle_t *devh,
     uvc_stream_ctrl_t *ctrl,
     uvc_frame_callback_t *cb,
     void *user_ptr,
-    uint8_t flags);
+    uint8_t flags,
+    int should_detach_kernel_driver);
 
 uvc_error_t uvc_start_iso_streaming(
     uvc_device_handle_t *devh,
     uvc_stream_ctrl_t *ctrl,
     uvc_frame_callback_t *cb,
-    void *user_ptr);
+    void *user_ptr,
+    int should_detach_kernel_driver);
 
 void uvc_stop_streaming(uvc_device_handle_t *devh);
 
-uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t **strmh, uvc_stream_ctrl_t *ctrl);
+uvc_error_t uvc_stream_open_ctrl(uvc_device_handle_t *devh, uvc_stream_handle_t **strmh, uvc_stream_ctrl_t *ctrl, int should_detach_kernel_driver);
 uvc_error_t uvc_stream_ctrl(uvc_stream_handle_t *strmh, uvc_stream_ctrl_t *ctrl);
 uvc_error_t uvc_stream_start(uvc_stream_handle_t *strmh,
     uvc_frame_callback_t *cb,

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -322,7 +322,7 @@ uvc_error_t uvc_query_stream_ctrl(
     enum uvc_req_code req);
 
 void uvc_start_handler_thread(uvc_context_t *ctx);
-uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx);
+uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx, int should_detach_kernel_driver);
 uvc_error_t uvc_release_if(uvc_device_handle_t *devh, int idx);
 
 #endif // !def(LIBUVC_INTERNAL_H)


### PR DESCRIPTION
Needs to be tested on Linux and on Windows. @pointcontrols mentioned, that this change might break building on Windows. If this is true, we need to add a case discrimination for the changes.